### PR TITLE
Not a Number (port)

### DIFF
--- a/index.js
+++ b/index.js
@@ -106,6 +106,11 @@ if(config['player']['enabled'] && config['server']['port'] == null || config['pl
     
     //ask for ip address
     config['server']['port'] = prompt("Enter Server Port (Enter to use default) >>> ");
+    
+    //make null if NaN
+    if(isNaN(config['server']['port'])){
+        config['server']['port'] = null;
+    }
 }
 
 //set mincraft player fullname


### PR DESCRIPTION
Great evolution of shit.

From:
```javascript
//get inline server port when config server port is null
if(config['player']['enabled'] && config['server']['port'] == null || config['player']['enabled'] && config['server']['port'] == ''){
    
    //ask for ip address
    config['server']['port'] = prompt("Enter Server Port (Enter to use default) >>> ");
}
```

To:
```javascript
//get inline server port when config server port is null
if(config['player']['enabled'] && config['server']['port'] == null || config['player']['enabled'] && config['server']['port'] == ''){
    
    //ask for ip address
    config['server']['port'] = prompt("Enter Server Port (Enter to use default) >>> ");
    
    //make null if NaN
    if(isNaN(config['server']['port'])){
        config['server']['port'] = null;
    }
}
```